### PR TITLE
Implements #43: Use EIP-712 for hashing

### DIFF
--- a/contracts/GnosisSafe.sol
+++ b/contracts/GnosisSafe.sol
@@ -8,6 +8,13 @@ import "./OwnerManager.sol";
 /// @author Stefan George - <stefan@gnosis.pm>
 contract GnosisSafe is ModuleManager, OwnerManager {
 
+    //keccak256(
+    //    "EIP712Domain(address verifyingContract)"
+    //);
+    bytes32 public constant DOMAIN_SEPERATOR_TYPEHASH = 0x035aff83d86937d35b32e04f0ddc6ff469290eef2f1b692d8a815c89404d4749;
+
+    bytes32 public domainSeperator;
+
     /// @dev Setup function sets initial storage of contract.
     /// @param _owners List of Safe owners.
     /// @param _threshold Number of required confirmations for a Safe transaction.
@@ -16,6 +23,8 @@ contract GnosisSafe is ModuleManager, OwnerManager {
     function setup(address[] _owners, uint256 _threshold, address to, bytes data)
         public
     {
+        require(domainSeperator == 0, "Domain Seperator already set!");
+        domainSeperator = keccak256(abi.encode(DOMAIN_SEPERATOR_TYPEHASH, this));
         setupOwners(_owners, _threshold);
         // As setupOwners can only be called if the contract has not been initialized we don't need a check for setupModules
         setupModules(to, data);

--- a/contracts/GnosisSafePersonalEdition.sol
+++ b/contracts/GnosisSafePersonalEdition.sol
@@ -13,6 +13,10 @@ contract GnosisSafePersonalEdition is MasterCopy, GnosisSafe, SignatureValidator
 
     string public constant NAME = "Gnosis Safe Personal Edition";
     string public constant VERSION = "0.0.1";
+    //keccak256(
+    //    "PersonalSafeTx(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 dataGas,uint256 gasPrice,address gasToken,uint256 nonce)"
+    //);
+    bytes32 public constant SAFE_TX_TYPEHASH = 0x068c3b33cc9bff6dde08209527b62abfb1d4ed576706e2078229623d72374b5b;
     
     event ExecutionFailed(bytes32 txHash);
 
@@ -135,8 +139,11 @@ contract GnosisSafePersonalEdition is MasterCopy, GnosisSafe, SignatureValidator
         view
         returns (bytes32)
     {
+        bytes32 safeTxHash = keccak256(
+            abi.encode(SAFE_TX_TYPEHASH, to, value, keccak256(data), operation, safeTxGas, dataGas, gasPrice, gasToken, _nonce)
+        );
         return keccak256(
-            abi.encodePacked(byte(0x19), byte(0), this, to, value, data, operation, safeTxGas, dataGas, gasPrice, gasToken, _nonce)
+            abi.encodePacked(byte(0x19), byte(1), domainSeperator, safeTxHash)
         );
     }
 }

--- a/contracts/GnosisSafeTeamEdition.sol
+++ b/contracts/GnosisSafeTeamEdition.sol
@@ -8,8 +8,12 @@ import "./MasterCopy.sol";
 /// @author Richard Meissner - <richard@gnosis.pm>
 contract GnosisSafeTeamEdition is MasterCopy, GnosisSafe {
 
-    string public constant NAME = "Gnosis Safe Team Edition";
+    string public constant NAME = "Gnosis Safe Team Edition"; 
     string public constant VERSION = "0.0.1";
+    //keccak256(
+    //    "TeamSafeTx(address to,uint256 value,bytes data,uint8 operation,uint256 nonce)"
+    //);
+    bytes32 public constant SAFE_TX_TYPEHASH = 0x5d1bba48ff479eb8a88ec6029f6b5eebc805c7dcb87470d5b1121d36d824c873;
 
     // isExecuted mapping allows to check if a transaction (by hash) was already executed.
     mapping (bytes32 => uint256) public isExecuted;
@@ -103,6 +107,11 @@ contract GnosisSafeTeamEdition is MasterCopy, GnosisSafe {
         view
         returns (bytes32)
     {
-        return keccak256(abi.encodePacked(byte(0x19), byte(0), this, to, value, data, operation, nonce));
+        bytes32 safeTxHash = keccak256(
+            abi.encode(SAFE_TX_TYPEHASH, to, value, keccak256(data), operation, nonce)
+        );
+        return keccak256(
+            abi.encodePacked(byte(0x19), byte(1), this, safeTxHash)
+        );
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3097,13 +3097,12 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "ganache-cli": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.1.2.tgz",
-      "integrity": "sha512-nnJ7Gz9dqpLglVqg6KRg+e5ifUhEW4l+BN58du3AKLUEPUVp/kP8YeRWBqjtk5P7ECh6Limj9aGfI3pRslr3Rw==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.1.7.tgz",
+      "integrity": "sha512-MwW9QZh5Prf0xZDwuWJsolVBO1ioRCU2ZE7ETJR4zakH6o3X8MmiObJyV/5CZHxIS1WVOeKowsdONhPjdyVjNA==",
       "dev": true,
       "requires": {
-        "source-map-support": "^0.5.3",
-        "webpack-cli": "^2.0.9"
+        "source-map-support": "^0.5.3"
       }
     },
     "get-caller-file": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "eth-lightwallet": "^3.0.1",
     "random-buffer": "*",
     "run-with-testrpc": "^0.3.0",
-    "ganache-cli": "6.1.2",
+    "ganache-cli": "6.1.7",
     "solidity-coverage": "^0.4.2",
     "truffle": "4.1.11",
     "web3": "0.20.6",

--- a/test/gnosisSafePersonalEditionEthSignTypeData.js
+++ b/test/gnosisSafePersonalEditionEthSignTypeData.js
@@ -1,0 +1,110 @@
+const utils = require('./utils')
+const safeUtils = require('./utilsPersonalSafe')
+
+
+const GnosisSafe = artifacts.require("./GnosisSafePersonalEdition.sol")
+const ProxyFactory = artifacts.require("./ProxyFactory.sol")
+
+
+contract('GnosisSafePersonalEdition using eth_signTypedData', function(accounts) {
+
+    let gnosisSafe
+    let executor = accounts[8]
+
+    const CALL = 0
+    const CREATE = 2
+
+    let signTypedData = async function(account, data) {
+        return new Promise(function (resolve, reject) {
+            web3.currentProvider.sendAsync({
+                jsonrpc: "2.0", 
+                method: "eth_signTypedData",
+                params: [account, data],
+                id: new Date().getTime()
+            }, function(err, response) {
+                if (err) { 
+                    return reject(err);
+                }
+                resolve(response.result);
+            });
+        });
+    }
+
+    beforeEach(async function () {
+        // Create Master Copies
+        let proxyFactory = await ProxyFactory.new()
+        let gnosisSafeMasterCopy = await GnosisSafe.new()
+        gnosisSafeMasterCopy.setup([accounts[0], accounts[1], accounts[2]], 2, 0, "0x")
+        // Create Gnosis Safe
+        let gnosisSafeData = await gnosisSafeMasterCopy.contract.setup.getData([accounts[0], accounts[1], accounts[2]], 2, 0, "0x")
+        gnosisSafe = utils.getParamFromTxEvent(
+            await proxyFactory.createProxy(gnosisSafeMasterCopy.address, gnosisSafeData),
+            'ProxyCreation', 'proxy', proxyFactory.address, GnosisSafe, 'create Gnosis Safe',
+        )
+    })
+
+    it('should deposit and withdraw 1 ETH', async () => {
+        // Deposit 1 ETH + some spare money for execution 
+        assert.equal(await web3.eth.getBalance(gnosisSafe.address), 0)
+        await web3.eth.sendTransaction({from: accounts[9], to: gnosisSafe.address, value: web3.toWei(1.1, 'ether')})
+        assert.equal(await web3.eth.getBalance(gnosisSafe.address).toNumber(), web3.toWei(1.1, 'ether'))
+
+        let executorBalance = await web3.eth.getBalance(executor).toNumber()
+
+        let confirmingAccounts = [accounts[0], accounts[2]]
+        let signer = async function(to, value, data, operation, txGasEstimate, dataGasEstimate, gasPrice, txGasToken, nonce) {
+            let typedData = {
+                types: {
+                    EIP712Domain: [
+                        { type: "address", name: "verifyingContract" }
+                    ],
+                    // "PersonalSafeTx(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 dataGas,uint256 gasPrice,address gasToken,uint256 nonce)"
+                    PersonalSafeTx: [
+                        { type: "address", name: "to" },
+                        { type: "uint256", name: "value" },
+                        { type: "bytes", name: "data" },
+                        { type: "uint8", name: "operation" },
+                        { type: "uint256", name: "safeTxGas" },
+                        { type: "uint256", name: "dataGas" },
+                        { type: "uint256", name: "gasPrice" },
+                        { type: "address", name: "gasToken" },
+                        { type: "uint256", name: "nonce" },
+                    ]
+                },
+                domain: {
+                    verifyingContract: gnosisSafe.address
+                },
+                primaryType: "PersonalSafeTx",
+                message: {
+                    to: to,
+                    value: value,
+                    data: data,
+                    operation: operation,
+                    safeTxGas: txGasEstimate,
+                    dataGas: dataGasEstimate,
+                    gasPrice: gasPrice,
+                    gasToken: txGasToken,
+                    nonce: nonce.toNumber()
+                }
+            }
+            let signatureBytes = "0x"
+            confirmingAccounts.sort()
+            for (var i=0; i<confirmingAccounts.length; i++) {
+                signatureBytes += (await signTypedData(confirmingAccounts[i], typedData)).replace('0x', '')
+            }
+            return signatureBytes
+        }
+
+        // Withdraw 1 ETH
+        await safeUtils.executeTransactionWithSigner(signer, gnosisSafe, 'executeTransaction withdraw 0.5 ETH', confirmingAccounts, accounts[9], web3.toWei(0.5, 'ether'), "0x", CALL, executor)
+
+        await safeUtils.executeTransactionWithSigner(signer, gnosisSafe, 'executeTransaction withdraw 0.5 ETH', confirmingAccounts, accounts[9], web3.toWei(0.5, 'ether'), "0x", CALL, executor)
+
+        // Should fail as it is over the balance (payment should still happen)
+        await safeUtils.executeTransactionWithSigner(signer, gnosisSafe, 'executeTransaction withdraw 0.5 ETH', confirmingAccounts, accounts[9], web3.toWei(0.5, 'ether'), "0x", CALL, executor, 0, true)
+
+        let executorDiff = await web3.eth.getBalance(executor) - executorBalance
+        console.log("    Executor earned " + web3.fromWei(executorDiff, 'ether') + " ETH")
+        assert.ok(executorDiff > 0)
+    })
+})

--- a/truffle.js
+++ b/truffle.js
@@ -8,7 +8,7 @@ module.exports = {
       host: "localhost",
       port: 8545,
       network_id: "*", // Match any network id
-      gas: 4600000
+      gas: 5000000
     },
     rinkeby: {
       provider: function() {


### PR DESCRIPTION
Implements #43: Use EIP-712 for hashing

Uses EIP-712 for hashing. This will allow other key stores to sign safe transactions (e.g. MetaMask, Ledger, Trezor). 

This introduces additional gas costs of ~20k on creation and ~700 per transaction.