### PR TITLE
Closes #36: Failed Safe transactions will reset confirmations

### DIFF
--- a/contracts/GnosisSafe.sol
+++ b/contracts/GnosisSafe.sol
@@ -29,4 +29,29 @@ contract GnosisSafe is ModuleManager, OwnerManager {
         // As setupOwners can only be called if the contract has not been initialized we don't need a check for setupModules
         setupModules(to, data);
     }
+
+    /// @dev Allows to estimate a Safe transaction. 
+    ///      This method is only meant for estimation purpose, therfore two different protection mechanism against execution in a transaction have been made:
+    ///      1.) The method can only be called from the safe itself
+    ///      2.) The response is returned with a revert
+    ///      When estimating set `from` to the address of the safe.
+    ///      Since the `estimateGas` function includes refunds, call this method to get an estimated of the costs required by the Safe to call `execute`
+    /// @param to Destination address of Safe transaction.
+    /// @param value Ether value of Safe transaction.
+    /// @param data Data payload of Safe transaction.
+    /// @param operation Operation type of Safe transaction.
+    /// @return Estimate without refunds and overhead fees (base transaction and payload data gas costs).
+    function requiredTxGas(address to, uint256 value, bytes data, Enum.Operation operation)
+        public
+        authorized
+        returns (uint256)
+    {
+        uint256 startGas = gasleft();
+        // We don't provide an error message here, as we use it to return the estimate
+        // solium-disable-next-line error-reason
+        require(execute(to, value, data, operation, gasleft()));
+        uint256 requiredGas = startGas - gasleft();
+        // Convert response to string and return via error message
+        revert(string(abi.encodePacked(requiredGas)));
+    }
 }

--- a/contracts/GnosisSafePersonalEdition.sol
+++ b/contracts/GnosisSafePersonalEdition.sol
@@ -90,6 +90,7 @@ contract GnosisSafePersonalEdition is MasterCopy, GnosisSafe, SignatureValidator
     {
         uint256 startGas = gasleft();
         // We don't provide an error message here, as we use it to return the estimate
+        // solium-disable-next-line error-reason
         require(execute(to, value, data, operation, gasleft()));
         uint256 requiredGas = startGas - gasleft();
         // Convert response to string and return via error message

--- a/contracts/GnosisSafePersonalEdition.sol
+++ b/contracts/GnosisSafePersonalEdition.sol
@@ -72,31 +72,6 @@ contract GnosisSafePersonalEdition is MasterCopy, GnosisSafe, SignatureValidator
         }  
     }
 
-    /// @dev Allows to estimate a Safe transaction. 
-    ///      This method is only meant for estimation purpose, therfore two different protection mechanism against execution in a transaction have been made:
-    ///      1.) The method can only be called from the safe itself
-    ///      2.) The response is returned with a revert
-    ///      When estimating set `from` to the address of the safe.
-    ///      Since the `estimateGas` function includes refunds, call this method to get an estimated of the costs that are deducted from the safe with `execTransactionAndPaySubmitter`
-    /// @param to Destination address of Safe transaction.
-    /// @param value Ether value of Safe transaction.
-    /// @param data Data payload of Safe transaction.
-    /// @param operation Operation type of Safe transaction.
-    /// @return Estimate without refunds and overhead fees (base transaction and payload data gas costs).
-    function requiredTxGas(address to, uint256 value, bytes data, Enum.Operation operation)
-        public
-        authorized
-        returns (uint256)
-    {
-        uint256 startGas = gasleft();
-        // We don't provide an error message here, as we use it to return the estimate
-        // solium-disable-next-line error-reason
-        require(execute(to, value, data, operation, gasleft()));
-        uint256 requiredGas = startGas - gasleft();
-        // Convert response to string and return via error message
-        revert(string(abi.encodePacked(requiredGas)));
-    }
-
     function checkHash(bytes32 txHash, bytes signatures)
         internal
         view

--- a/contracts/GnosisSafeTeamEdition.sol
+++ b/contracts/GnosisSafeTeamEdition.sol
@@ -88,31 +88,6 @@ contract GnosisSafeTeamEdition is MasterCopy, GnosisSafe {
         }
     }
 
-    /// @dev Allows to estimate a Safe transaction. 
-    ///      This method is only meant for estimation purpose, therfore two different protection mechanism against execution in a transaction have been made:
-    ///      1.) The method can only be called from the safe itself
-    ///      2.) The response is returned with a revert
-    ///      When estimating set `from` to the address of the safe.
-    ///      Since the `estimateGas` function includes refunds, call this method to get an estimated of the costs that are deducted from the safe with `execTransactionAndPaySubmitter`
-    /// @param to Destination address of Safe transaction.
-    /// @param value Ether value of Safe transaction.
-    /// @param data Data payload of Safe transaction.
-    /// @param operation Operation type of Safe transaction.
-    /// @return Estimate without refunds and overhead fees (base transaction and payload data gas costs).
-    function requiredTxGas(address to, uint256 value, bytes data, Enum.Operation operation)
-        public
-        authorized
-        returns (uint256)
-    {
-        uint256 startGas = gasleft();
-        // We don't provide an error message here, as we use it to return the estimate
-        // solium-disable-next-line error-reason
-        require(execute(to, value, data, operation, gasleft()));
-        uint256 requiredGas = startGas - gasleft();
-        // Convert response to string and return via error message
-        revert(string(abi.encodePacked(requiredGas)));
-    }
-
     function checkAndClearConfirmations(bytes32 transactionHash)
         internal
     {

--- a/contracts/GnosisSafeTeamEdition.sol
+++ b/contracts/GnosisSafeTeamEdition.sol
@@ -81,7 +81,7 @@ contract GnosisSafeTeamEdition is MasterCopy, GnosisSafe {
         checkAndClearConfirmations(transactionHash);
         // Mark as executed and execute transaction.
         isExecuted[transactionHash] = 1;
-        //require(gasleft() >= safeTxGas, "Not enough gas to execute safe transaction");
+        require(gasleft() >= safeTxGas, "Not enough gas to execute safe transaction");
         success = execute(to, value, data, operation, safeTxGas);
         if (!success) {
             emit ExecutionFailed(transactionHash);

--- a/contracts/GnosisSafeTeamEdition.sol
+++ b/contracts/GnosisSafeTeamEdition.sol
@@ -11,9 +11,11 @@ contract GnosisSafeTeamEdition is MasterCopy, GnosisSafe {
     string public constant NAME = "Gnosis Safe Team Edition"; 
     string public constant VERSION = "0.0.1";
     //keccak256(
-    //    "TeamSafeTx(address to,uint256 value,bytes data,uint8 operation,uint256 nonce)"
+    //    "TeamSafeTx(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 nonce)"
     //);
-    bytes32 public constant SAFE_TX_TYPEHASH = 0x5d1bba48ff479eb8a88ec6029f6b5eebc805c7dcb87470d5b1121d36d824c873;
+    bytes32 public constant SAFE_TX_TYPEHASH = 0xaca975962d0b87e32d17d995e0fac3bcaf2717b65affa35cb60138c4f1784d32;
+    
+    event ExecutionFailed(bytes32 txHash);
 
     // isExecuted mapping allows to check if a transaction (by hash) was already executed.
     mapping (bytes32 => uint256) public isExecuted;
@@ -42,16 +44,18 @@ contract GnosisSafeTeamEdition is MasterCopy, GnosisSafe {
     /// @param data Data payload of Safe transaction.
     /// @param operation Operation type of Safe transaction.
     /// @param nonce Nonce used for this Safe transaction.
+    /// @param safeTxGas Gas that should be available for the Safe transaction.
     function approveTransactionWithParameters(
         address to, 
         uint256 value, 
         bytes data, 
         Enum.Operation operation, 
+        uint256 safeTxGas,
         uint256 nonce
     )
         public
     {
-        approveTransactionByHash(getTransactionHash(to, value, data, operation, nonce));
+        approveTransactionByHash(getTransactionHash(to, value, data, operation, safeTxGas, nonce));
     }
 
     /// @dev Allows to execute a Safe transaction confirmed by required number of owners. If the sender is an owner this is automatically confirmed.
@@ -59,22 +63,53 @@ contract GnosisSafeTeamEdition is MasterCopy, GnosisSafe {
     /// @param value Ether value of Safe transaction.
     /// @param data Data payload of Safe transaction.
     /// @param operation Operation type of Safe transaction.
+    /// @param safeTxGas Gas that should be available for the Safe transaction.
     /// @param nonce Nonce used for this Safe transaction.
     function execTransactionIfApproved(
         address to, 
         uint256 value, 
         bytes data, 
         Enum.Operation operation, 
+        uint256 safeTxGas,
         uint256 nonce
     )
         public
+        returns (bool success)
     {
-        bytes32 transactionHash = getTransactionHash(to, value, data, operation, nonce);
+        bytes32 transactionHash = getTransactionHash(to, value, data, operation, safeTxGas, nonce);
         require(isExecuted[transactionHash] == 0, "Safe transaction already executed");
         checkAndClearConfirmations(transactionHash);
         // Mark as executed and execute transaction.
         isExecuted[transactionHash] = 1;
-        require(execute(to, value, data, operation, gasleft()), "Could not execute safe transaction");
+        //require(gasleft() >= safeTxGas, "Not enough gas to execute safe transaction");
+        success = execute(to, value, data, operation, safeTxGas);
+        if (!success) {
+            emit ExecutionFailed(transactionHash);
+        }
+    }
+
+    /// @dev Allows to estimate a Safe transaction. 
+    ///      This method is only meant for estimation purpose, therfore two different protection mechanism against execution in a transaction have been made:
+    ///      1.) The method can only be called from the safe itself
+    ///      2.) The response is returned with a revert
+    ///      When estimating set `from` to the address of the safe.
+    ///      Since the `estimateGas` function includes refunds, call this method to get an estimated of the costs that are deducted from the safe with `execTransactionAndPaySubmitter`
+    /// @param to Destination address of Safe transaction.
+    /// @param value Ether value of Safe transaction.
+    /// @param data Data payload of Safe transaction.
+    /// @param operation Operation type of Safe transaction.
+    /// @return Estimate without refunds and overhead fees (base transaction and payload data gas costs).
+    function requiredTxGas(address to, uint256 value, bytes data, Enum.Operation operation)
+        public
+        authorized
+        returns (uint256)
+    {
+        uint256 startGas = gasleft();
+        // We don't provide an error message here, as we use it to return the estimate
+        require(execute(to, value, data, operation, gasleft()));
+        uint256 requiredGas = startGas - gasleft();
+        // Convert response to string and return via error message
+        revert(string(abi.encodePacked(requiredGas)));
     }
 
     function checkAndClearConfirmations(bytes32 transactionHash)
@@ -90,7 +125,7 @@ contract GnosisSafeTeamEdition is MasterCopy, GnosisSafe {
                 if (ownerConfirmed) {
                     approvals[currentOwner] = 0;
                 }
-                confirmations ++;
+                confirmations++;
             }
             currentOwner = owners[currentOwner];
         }
@@ -102,6 +137,7 @@ contract GnosisSafeTeamEdition is MasterCopy, GnosisSafe {
     /// @param value Ether value.
     /// @param data Data payload.
     /// @param operation Operation type.
+    /// @param safeTxGas Fas that should be used for the safe transaction.
     /// @param nonce Transaction nonce.
     /// @return Transaction hash.
     function getTransactionHash(
@@ -109,6 +145,7 @@ contract GnosisSafeTeamEdition is MasterCopy, GnosisSafe {
         uint256 value, 
         bytes data, 
         Enum.Operation operation, 
+        uint256 safeTxGas, 
         uint256 nonce
     )
         public
@@ -116,10 +153,10 @@ contract GnosisSafeTeamEdition is MasterCopy, GnosisSafe {
         returns (bytes32)
     {
         bytes32 safeTxHash = keccak256(
-            abi.encode(SAFE_TX_TYPEHASH, to, value, keccak256(data), operation, nonce)
+            abi.encode(SAFE_TX_TYPEHASH, to, value, keccak256(data), operation, safeTxGas, nonce)
         );
         return keccak256(
-            abi.encodePacked(byte(0x19), byte(1), this, safeTxHash)
+            abi.encodePacked(byte(0x19), byte(1), domainSeperator, safeTxHash)
         );
     }
 }

--- a/contracts/GnosisSafeTeamEdition.sol
+++ b/contracts/GnosisSafeTeamEdition.sol
@@ -106,6 +106,7 @@ contract GnosisSafeTeamEdition is MasterCopy, GnosisSafe {
     {
         uint256 startGas = gasleft();
         // We don't provide an error message here, as we use it to return the estimate
+        // solium-disable-next-line error-reason
         require(execute(to, value, data, operation, gasleft()));
         uint256 requiredGas = startGas - gasleft();
         // Convert response to string and return via error message

--- a/contracts/SignatureValidator.sol
+++ b/contracts/SignatureValidator.sol
@@ -15,8 +15,8 @@ contract SignatureValidator {
         bytes messageSignature,
         uint256 pos
     )
-        pure
         internal
+        pure
         returns (address) 
     {
         uint8 v;
@@ -30,8 +30,8 @@ contract SignatureValidator {
     /// @param pos which signature to read
     /// @param signatures concatenated rsv signatures
     function signatureSplit(bytes signatures, uint256 pos)
-        pure
         internal
+        pure
         returns (uint8 v, bytes32 r, bytes32 s)
     {
         // The signature format is a compact form of:

--- a/test/gnosisSafeTeamEdition.js
+++ b/test/gnosisSafeTeamEdition.js
@@ -1,5 +1,6 @@
 const utils = require('./utils')
 const solc = require('solc')
+const BigNumber = require('bignumber.js');
 
 const GnosisSafe = artifacts.require("./GnosisSafeTeamEdition.sol")
 const ProxyFactory = artifacts.require("./ProxyFactory.sol")
@@ -19,25 +20,41 @@ contract('GnosisSafeTeamEdition', function(accounts) {
         let options = opts || {}
         let txSender = options.sender || executor 
         let nonce = utils.currentTimeNs()
-        
-        let executeData = gnosisSafe.contract.execTransactionIfApproved.getData(to, value, data, operation, nonce)
+        // Estimate safe transaction (need to be called with from set to the safe address)
+        let txGasEstimate = 0
+        let estimateResponse
+        try {
+            let estimateData = gnosisSafe.contract.requiredTxGas.getData(to, value, data, operation)
+            estimateResponse = await web3.eth.call({to: gnosisSafe.address, from: gnosisSafe.address, data: estimateData})
+            txGasEstimate = new BigNumber(estimateResponse.substring(138), 16)
+            // Add 10k else we will fail in case of nested calls
+            txGasEstimate = txGasEstimate.toNumber() + 10000
+            console.log("    Tx Gas estimate: " + txGasEstimate)
+        } catch(e) {
+            let reason = estimateResponse || "Unknown error"
+            console.log("    Could not estimate " + subject + " (" + reason + ")")
+            console.log(e)
+        }
+
+        let executeData = gnosisSafe.contract.execTransactionIfApproved.getData(to, value, data, operation, txGasEstimate, nonce)
         assert.equal(await utils.getErrorMessage(gnosisSafe.address, 0, executeData), "Not enough confirmations")
 
-        let approveData = gnosisSafe.contract.approveTransactionWithParameters.getData(to, value, data, operation, nonce)
+        let approveData = gnosisSafe.contract.approveTransactionWithParameters.getData(to, value, data, operation, txGasEstimate, nonce)
         assert.equal(await utils.getErrorMessage(gnosisSafe.address, 0, approveData, "0x0000000000000000000000000000000000000002"), "Sender is not an owner")
         
         if (options.approveByHash) {
-            let txHash = await gnosisSafe.getTransactionHash(to, value, data, operation, nonce)
+            let txHash = await gnosisSafe.getTransactionHash(to, value, data, operation, txGasEstimate, nonce)
             for (let account of (accounts.filter(a => a != txSender))) {
                 utils.logGasUsage("confirm by hash " + subject + " with " + account, await gnosisSafe.approveTransactionByHash(txHash, {from: account}))
             }
         } else {
             for (let account of (accounts.filter(a => a != txSender))) {
-                utils.logGasUsage("confirm " + subject + " with " + account, await gnosisSafe.approveTransactionWithParameters(to, value, data, operation, nonce, {from: account}))
+                utils.logGasUsage("confirm " + subject + " with " + account, await gnosisSafe.approveTransactionWithParameters(to, value, data, operation, txGasEstimate, nonce, {from: account}))
             }
         }
 
-        let tx = await gnosisSafe.execTransactionIfApproved(to, value, data, operation, nonce, {from: txSender})
+        assert.equal(await utils.getErrorMessage(gnosisSafe.address, 0, executeData, txSender, 40000), "Not enough confirmations")
+        let tx = await gnosisSafe.execTransactionIfApproved(to, value, data, operation, txGasEstimate, nonce, {from: txSender})
         utils.logGasUsage(subject, tx)
 
         assert.equal(await utils.getErrorMessage(gnosisSafe.address, 0, approveData, accounts[0]), "Safe transaction already executed")

--- a/test/gnosisSafeTeamEdition.js
+++ b/test/gnosisSafeTeamEdition.js
@@ -53,7 +53,6 @@ contract('GnosisSafeTeamEdition', function(accounts) {
             }
         }
 
-        assert.equal(await utils.getErrorMessage(gnosisSafe.address, 0, executeData, txSender, 40000), "Not enough confirmations")
         let tx = await gnosisSafe.execTransactionIfApproved(to, value, data, operation, txGasEstimate, nonce, {from: txSender})
         utils.logGasUsage(subject, tx)
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -112,8 +112,8 @@ async function assertRejects(q, msg) {
     return res
 }
 
-async function getErrorMessage(to, value, data, from) {
-    let returnData = await web3.eth.call({to: to, from: from, value: value, data: data})
+async function getErrorMessage(to, value, data, from, gas) {
+    let returnData = await web3.eth.call({to: to, from: from, value: value, data: data, gas: gas})
     let returnBuffer = Buffer.from(returnData.slice(2), "hex")
     return abi.rawDecode(["string"], returnBuffer.slice(4))[0];
 }


### PR DESCRIPTION
To prevent that stale approvals of failing transactions can be used at a later point failing safe transactions will reset confirmations.

For this we add the safeTxGas to make sure that the Safe transaction cannot be failed on purpose by sending to little gas.

- [x] Move estimate required gas function into separate contract for reuse