### PR TITLE
Upgrade MockContract to version 2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dev": true
     },
     "@gnosis.pm/mock-contract": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@gnosis.pm/mock-contract/-/mock-contract-1.0.1.tgz",
-      "integrity": "sha512-XkqDBpdsbEuNhYc1/PrfOh4pluAE1tnYRfiY8Er2dNAXG2FEEFXqCoLjZYrhgSy0zVgtIKO/b7P6fWB5RLLGzg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@gnosis.pm/mock-contract/-/mock-contract-2.0.0.tgz",
+      "integrity": "sha512-S7vZcdG74Yo76+ZpVyXZ1MFNiu8m0yxIrO5pi3zLz6/gH1bPmDhvCheq69ro7cPrC6hzALn8WPNE55mw1G7Y2w==",
       "dev": true,
       "requires": {
         "ethereumjs-abi": "^0.6.5"
@@ -2398,6 +2398,10 @@
         "web3": "0.20.2"
       },
       "dependencies": {
+        "bignumber.js": {
+          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+        },
         "web3": {
           "version": "0.20.2",
           "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.2.tgz",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@digix/tempo": "^0.2.0",
-    "@gnosis.pm/mock-contract": "1.0.1",
+    "@gnosis.pm/mock-contract": "2.0.0",
     "bignumber.js": "^7.1.0",
     "eth-lightwallet": "^3.0.1",
     "ethereumjs-abi": "^0.6.5",

--- a/test/gnosisSafePersonalEditionCreation.js
+++ b/test/gnosisSafePersonalEditionCreation.js
@@ -4,7 +4,6 @@ const fs = require('fs')
 const randomBuffer = require("random-buffer")
 const ethUtil = require('ethereumjs-util')
 const EthereumTx = require('ethereumjs-tx')
-const abi = require('ethereumjs-abi');
 
 const GnosisSafe = artifacts.require("./GnosisSafe.sol")
 const MockContract = artifacts.require('./MockContract.sol');
@@ -13,7 +12,6 @@ const MockToken = artifacts.require('./Token.sol');
 contract('GnosisSafePersonalEdition', function(accounts) {
 
     const CALL = 0
-    const method = "0x" + abi.methodID('transfer', ['address', 'uint256']).toString('hex');
 
     const gasPrice = web3.toWei('20', 'gwei')
     const payingProxyJson = JSON.parse(fs.readFileSync("./build/contracts/PayingProxy.json"))
@@ -169,19 +167,19 @@ contract('GnosisSafePersonalEdition', function(accounts) {
         let mockContract = await MockContract.new();
         let mockToken = MockToken.at(mockContract.address);
 
-        await mockContract.givenOutOfGasAny(method);
+        await mockContract.givenAnyRunOutOfGas();
         creationData = await getCreationData(mockToken.address, 1337)
         await deployWithCreationData(creationData);
         assert.equal(await web3.eth.getCode(creationData.safe), '0x0');
 
 
-        await mockContract.givenRevertAny(method);
+        await mockContract.givenAnyRevert();
         creationData = await getCreationData(mockToken.address, 1337);
         await deployWithCreationData(creationData);
         assert.equal(await web3.eth.getCode(creationData.safe), '0x0');
 
 
-        await mockContract.givenReturnAny(method, abi.rawEncode(['bool'], [false]).toString());
+        await mockContract.givenAnyReturnBool(false);
         creationData = await getCreationData(mockToken.address, 1337);
         await deployWithCreationData(creationData);
         assert.equal(await web3.eth.getCode(creationData.safe), '0x0');


### PR DESCRIPTION
New API has breaking changes but makes interaction much simpler. No more need for cumbersome abi.encoding in JS.

Ran truffle test to verify everything still works.