### PR TITLE
Disable optimizer

### DIFF
--- a/truffle.js
+++ b/truffle.js
@@ -34,7 +34,7 @@ module.exports = {
   },
   solc: {
     optimizer: {
-      enabled: true
+      enabled: false
     },
   },
 };


### PR DESCRIPTION
- This was enabled for test deployment on Rinkeby (as the block gas limit was too low for some contracts).
- No production contracts (neither for Rinkeby nor Mainnet) were deployed using this option