### PR TITLE
Include build artifacts in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,14 @@
   "license": "GPL-3.0",
   "main": "index.js",
   "files": [
+    "build",
     "contracts",
     "test",
     "zos.json",
     "zos.*.json"
   ],
   "scripts": {
+    "prepare": "rm -rf build/contracts && truffle compile",
     "test-norpc": "truffle test",
     "test": "run-with-testrpc -l 20000000 --noVMErrorsOnRPCResponse true 'truffle test'"
   },


### PR DESCRIPTION
Including the contents of build/contracts in the npm package is required so users can link to the project as an EVM package. This changeset adds a `prepare` script to ensure contracts are compiled before publishing, and includes the build folder in the package definition.

See https://docs.zeppelinos.org/docs/publishing.html for more info.