### PR TITLE
Close #130: Add method to access master copy

### DIFF
--- a/contracts/proxies/Proxy.sol
+++ b/contracts/proxies/Proxy.sol
@@ -1,5 +1,8 @@
 pragma solidity ^0.5.0;
 
+interface IProxy {
+    function masterCopy() external view returns (address);
+}
 
 /// @title Proxy - Generic proxy contract allows to execute all transactions applying the code of a master contract.
 /// @author Stefan George - <stefan@gnosis.io>
@@ -27,6 +30,11 @@ contract Proxy {
         // solium-disable-next-line security/no-inline-assembly
         assembly {
             let masterCopy := and(sload(0), 0xffffffffffffffffffffffffffffffffffffffff)
+            // 0xa619486e == keccak("masterCopy()"). The value is right padded to 32-bytes with 0s
+            if eq(calldataload(0), 0xa619486e00000000000000000000000000000000000000000000000000000000) {
+                mstore(0, masterCopy)
+                return(0, 0x20)
+            }
             calldatacopy(0, 0, calldatasize())
             let success := delegatecall(gas, masterCopy, 0, calldatasize(), 0, 0)
             returndatacopy(0, 0, returndatasize())

--- a/contracts/proxies/Proxy.sol
+++ b/contracts/proxies/Proxy.sol
@@ -1,5 +1,7 @@
 pragma solidity ^0.5.0;
 
+/// @title IProxy - Helper interface to access masterCopy of the Proxy on-chain
+/// @author Richard Meissner - <richard@gnosis.io>
 interface IProxy {
     function masterCopy() external view returns (address);
 }

--- a/test/gnosisSafeDeploymentViaCreate2.js
+++ b/test/gnosisSafeDeploymentViaCreate2.js
@@ -5,6 +5,7 @@ const abi = require('ethereumjs-abi')
 
 const GnosisSafe = artifacts.require("./GnosisSafe.sol")
 const Proxy = artifacts.require("./Proxy.sol")
+const ProxyInterface = artifacts.require("./IProxy.sol")
 const ProxyFactory = artifacts.require("./ProxyFactory.sol")
 const MockContract = artifacts.require('./MockContract.sol')
 const MockToken = artifacts.require('./Token.sol')
@@ -59,6 +60,8 @@ contract('GnosisSafe via create2', function(accounts) {
 
       console.log("    Deployed safe address: " + safeAddress)
       assert.equal(estimatedAddress, safeAddress)
+      let proxy = ProxyInterface.at(safeAddress)
+      assert.equal(await proxy.masterCopy(), gnosisSafeMasterCopy.address)
     }
 
     beforeEach(async function () {


### PR DESCRIPTION
Closes #130 

This PR adds a way to pull the master copy of a proxy on chain.

The costs on deployment increase by 10k gas because of this change (~ 5%), but there is close to no change in the execution costs per transaction.