### PR TITLE
Update version pragma to include 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ solidity_flattener contracts/modules/SocialRecoveryModule.sol --output build/fla
 solidity_flattener contracts/modules/StateChannelModule.sol --output build/flattened_contracts/StateChannelModule.sol --solc-paths="/=/"
 solidity_flattener contracts/modules/WhitelistModule.sol --output build/flattened_contracts/WhitelistModule.sol --solc-paths="/=/"
 solidity_flattener contracts/proxies/ProxyFactory.sol --output build/flattened_contracts/ProxyFactory.sol
-find build/flattened_contracts -name '*.sol' -exec sed -i '' 's/pragma solidity ^0.4.13;/pragma solidity ^0.5.0;/g' {} \;
+find build/flattened_contracts -name '*.sol' -exec sed -i '' 's/pragma solidity ^0.4.13;/pragma solidity >=0.5.0 <0.7.0;/g' {} \;
 ```
 
 Using with ZeppelinOS

--- a/contracts/GnosisSafe.sol
+++ b/contracts/GnosisSafe.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 import "./base/ModuleManager.sol";
 import "./base/OwnerManager.sol";
 import "./base/FallbackManager.sol";

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 
 contract Migrations {
     address public owner;

--- a/contracts/base/Executor.sol
+++ b/contracts/base/Executor.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 import "../common/Enum.sol";
 
 

--- a/contracts/base/FallbackManager.sol
+++ b/contracts/base/FallbackManager.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 
 import "../common/SelfAuthorized.sol";
 

--- a/contracts/base/Module.sol
+++ b/contracts/base/Module.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 import "../common/MasterCopy.sol";
 import "./ModuleManager.sol";
 

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 import "../common/Enum.sol";
 import "../common/SelfAuthorized.sol";
 import "./Executor.sol";

--- a/contracts/base/OwnerManager.sol
+++ b/contracts/base/OwnerManager.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 import "../common/SelfAuthorized.sol";
 
 /// @title OwnerManager - Manages a set of owners and a threshold to perform actions.

--- a/contracts/common/Enum.sol
+++ b/contracts/common/Enum.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 
 
 /// @title Enum - Collection of enums

--- a/contracts/common/EtherPaymentFallback.sol
+++ b/contracts/common/EtherPaymentFallback.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 
 
 /// @title EtherPaymentFallback - A contract that has a fallback to accept ether payments

--- a/contracts/common/MasterCopy.sol
+++ b/contracts/common/MasterCopy.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 import "./SelfAuthorized.sol";
 
 

--- a/contracts/common/SecuredTokenTransfer.sol
+++ b/contracts/common/SecuredTokenTransfer.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 
 
 /// @title SecuredTokenTransfer - Secure token transfer

--- a/contracts/common/SelfAuthorized.sol
+++ b/contracts/common/SelfAuthorized.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 
 
 /// @title SelfAuthorized - authorizes current contract to perform actions

--- a/contracts/common/SignatureDecoder.sol
+++ b/contracts/common/SignatureDecoder.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 
 
 /// @title SignatureDecoder - Decodes signatures that a encoded as bytes

--- a/contracts/external/SafeMath.sol
+++ b/contracts/external/SafeMath.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 
 /**
  * @title SafeMath

--- a/contracts/handler/DefaultCallbackHandler.sol
+++ b/contracts/handler/DefaultCallbackHandler.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 
 import "../interfaces/ERC1155TokenReceiver.sol";
 import "../interfaces/ERC721TokenReceiver.sol";

--- a/contracts/interfaces/ERC1155TokenReceiver.sol
+++ b/contracts/interfaces/ERC1155TokenReceiver.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 
 /**
     Note: The ERC-165 identifier for this interface is 0x4e2312e0.

--- a/contracts/interfaces/ERC721TokenReceiver.sol
+++ b/contracts/interfaces/ERC721TokenReceiver.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 
 /// @dev Note: the ERC-165 identifier for this interface is 0x150b7a02.
 interface ERC721TokenReceiver {

--- a/contracts/interfaces/ERC777TokensRecipient.sol
+++ b/contracts/interfaces/ERC777TokensRecipient.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 
 interface ERC777TokensRecipient {
     function tokensReceived(

--- a/contracts/interfaces/ISignatureValidator.sol
+++ b/contracts/interfaces/ISignatureValidator.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 
 contract ISignatureValidatorConstants {
     // bytes4(keccak256("isValidSignature(bytes,bytes)")

--- a/contracts/libraries/CreateAndAddModules.sol
+++ b/contracts/libraries/CreateAndAddModules.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 import "../base/Module.sol";
 
 

--- a/contracts/libraries/CreateCall.sol
+++ b/contracts/libraries/CreateCall.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 
 
 /// @title Create Call - Allows to use the different create opcodes to deploy a contract

--- a/contracts/libraries/MultiSend.sol
+++ b/contracts/libraries/MultiSend.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 
 
 /// @title Multi Send - Allows to batch multiple transactions into one.

--- a/contracts/mocks/ERC1155Token.sol
+++ b/contracts/mocks/ERC1155Token.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 
 import "../interfaces/ERC1155TokenReceiver.sol";
 import "../external/SafeMath.sol";

--- a/contracts/mocks/Token.sol
+++ b/contracts/mocks/Token.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 import "@gnosis.pm/mock-contract/contracts/MockContract.sol";
 contract Token {
 	function transfer(address _to, uint value) public returns (bool);

--- a/contracts/modules/DailyLimitModule.sol
+++ b/contracts/modules/DailyLimitModule.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 import "../base/Module.sol";
 import "../base/ModuleManager.sol";
 import "../base/OwnerManager.sol";

--- a/contracts/modules/SocialRecoveryModule.sol
+++ b/contracts/modules/SocialRecoveryModule.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 import "../base/Module.sol";
 import "../base/ModuleManager.sol";
 import "../base/OwnerManager.sol";

--- a/contracts/modules/StateChannelModule.sol
+++ b/contracts/modules/StateChannelModule.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 import "../base/Module.sol";
 import "../base/OwnerManager.sol";
 import "../common/Enum.sol";

--- a/contracts/modules/WhitelistModule.sol
+++ b/contracts/modules/WhitelistModule.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 import "../base/Module.sol";
 import "../base/ModuleManager.sol";
 import "../base/OwnerManager.sol";

--- a/contracts/proxies/DelegateConstructorProxy.sol
+++ b/contracts/proxies/DelegateConstructorProxy.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 import "./Proxy.sol";
 
 

--- a/contracts/proxies/PayingProxy.sol
+++ b/contracts/proxies/PayingProxy.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 import "../common/SecuredTokenTransfer.sol";
 import "./DelegateConstructorProxy.sol";
 

--- a/contracts/proxies/Proxy.sol
+++ b/contracts/proxies/Proxy.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.7.0;
 
 
 /// @title Proxy - Generic proxy contract allows to execute all transactions applying the code of a master contract.


### PR DESCRIPTION
The Solidity project runs `safe-contracts` tests against nightly solc-js builds and one of them is a 0.6.0 build. Compilation fails because of the restrictive version pragma, which this PR relaxes in order to also include 0.6.0.

In case these changes should not be merged into `development`, we'd be also more than happy to have a dedicated 0.6.0 branch in this repository :) Such a branch could be updated by us with every new breaking change we introduce.