### PR TITLE
Remove incoming transaction event

### DIFF
--- a/contracts/base/FallbackManager.sol
+++ b/contracts/base/FallbackManager.sol
@@ -6,8 +6,6 @@ import "../common/SelfAuthorized.sol";
 /// @author Richard Meissner - <richard@gnosis.pm>
 contract FallbackManager is SelfAuthorized {
 
-    event IncomingTransaction(address from, uint256 value);
-
     // keccak256("fallback_manager.handler.address")
     bytes32 internal constant FALLBACK_HANDLER_STORAGE_SLOT = 0x6c9a6c4a39284e37ed1cf53d337577d14212a4870fb976a4366c693b939918d5;
 
@@ -36,12 +34,6 @@ contract FallbackManager is SelfAuthorized {
     {
         // Only calls without value and with data will be forwarded
         if (msg.value > 0 || msg.data.length == 0) {
-            // If this was called from an EOA or we have enough gas, then we should emit an event
-            // Note: we check the origin to avoid that EOA transactions are estimated to low to emit the event
-            // solium-disable-next-line security/no-tx-origin
-            if (msg.sender == tx.origin || gasleft() > 1500) {
-                emit IncomingTransaction(msg.sender, msg.value);
-            }
             return;
         }
         bytes32 slot = FALLBACK_HANDLER_STORAGE_SLOT;


### PR DESCRIPTION
As a result of the audit it was recommended to remove this event, because it is not dependable in the current implementation and might break with future gas changes.

@Georgi87 @Uxio0 what do you think?