### PR TITLE
fix ERC-1271 interface

### DIFF
--- a/test/gnosisSafeSignatureTypes.js
+++ b/test/gnosisSafeSignatureTypes.js
@@ -23,11 +23,16 @@ contract('GnosisSafe without refund', function(accounts) {
         assert.equal(await utils.getErrorMessage(gnosisSafe.address, 0, approveData, executor), "Only owners can approve a hash")
 
         let sigs = "0x"
+        var i = 0;
         for (let account of (accounts.sort())) {
             if (account != txSender) {
+                i++;
                 utils.logGasUsage("confirm by hash " + subject + " with " + account, await gnosisSafe.approveHash(txHash, {from: account}))
+                sigs += "00000000000000000000000000000000000000000000000000000000000000" + ("0" + (i).toString('16')).slice(-2) + "0000000000000000000000000000000000000000000000000000000000000000" + "02"
+            } else {
+                sigs += "000000000000000000000000" + account.replace('0x', '') + "0000000000000000000000000000000000000000000000000000000000000000" + "01"
             }
-            sigs += "000000000000000000000000" + account.replace('0x', '') + "0000000000000000000000000000000000000000000000000000000000000000" + "01"
+            
         }
 
         let tx = await gnosisSafe.execTransaction(to, value, data, operation, 0, 0, 0, 0, 0, sigs, {from: txSender})


### PR DESCRIPTION
Fixes #166 
The current GnosisSafe.sol implenets ERC-1271 `isValidSignature(bytes,bytes)` as an external (executable) function, while the correct should be a public view.

This PR makes the interface compilant with:
https://github.com/gnosis/safe-contracts/blob/892448e93f6203b530630f20de45d8a55fde7463/contracts/interfaces/ISignatureValidator.sol#L19-L24

And also changes how the storage is handled, with the help of an auxiliary storage contract, that can be selfdestructed to delete all the storage with one call (avoids `for loops` or cleaning up during signature check).

### ToDos:
- [ ] If this gets merged create a issue to update the docs