### PR TITLE
Dependency Rename to Avoid Collision on Integration

### DIFF
--- a/contracts/GnosisSafe.sol
+++ b/contracts/GnosisSafe.sol
@@ -6,7 +6,7 @@ import "./common/MasterCopy.sol";
 import "./common/SignatureDecoder.sol";
 import "./common/SecuredTokenTransfer.sol";
 import "./interfaces/ISignatureValidator.sol";
-import "./external/SafeMath.sol";
+import "./external/GnosisSafeMath.sol";
 
 /// @title Gnosis Safe - A multisignature wallet with support for confirmations using signed messages based on ERC191.
 /// @author Stefan George - <stefan@gnosis.io>
@@ -15,7 +15,7 @@ import "./external/SafeMath.sol";
 contract GnosisSafe
     is MasterCopy, ModuleManager, OwnerManager, SignatureDecoder, SecuredTokenTransfer, ISignatureValidatorConstants, FallbackManager {
 
-    using SafeMath for uint256;
+    using GnosisSafeMath for uint256;
 
     string public constant NAME = "Gnosis Safe";
     string public constant VERSION = "1.1.1";

--- a/contracts/external/GnosisSafeMath.sol
+++ b/contracts/external/GnosisSafeMath.sol
@@ -1,11 +1,11 @@
 pragma solidity >=0.5.0 <0.7.0;
 
 /**
- * @title SafeMath
+ * @title GnosisSafeMath
  * @dev Math operations with safety checks that revert on error
  * TODO: remove once open zeppelin update to solc 0.5.0
  */
-library SafeMath {
+library GnosisSafeMath {
 
   /**
   * @dev Multiplies two numbers, reverts on overflow.

--- a/contracts/mocks/ERC1155Token.sol
+++ b/contracts/mocks/ERC1155Token.sol
@@ -1,11 +1,11 @@
 pragma solidity >=0.5.0 <0.7.0;
 
 import "../interfaces/ERC1155TokenReceiver.sol";
-import "../external/SafeMath.sol";
+import "../external/GnosisSafeMath.sol";
 
 contract ERC1155Token {
 
-    using SafeMath for uint256;
+    using GnosisSafeMath for uint256;
 
     // Mapping from token ID to owner balances
     mapping (uint256 => mapping(address => uint256)) private _balances;

--- a/contracts/proxies/GnosisSafeProxy.sol
+++ b/contracts/proxies/GnosisSafeProxy.sol
@@ -9,7 +9,7 @@ interface IProxy {
 /// @title Proxy - Generic proxy contract allows to execute all transactions applying the code of a master contract.
 /// @author Stefan George - <stefan@gnosis.io>
 /// @author Richard Meissner - <richard@gnosis.io>
-contract Proxy {
+contract GnosisSafeProxy {
 
     // masterCopy always needs to be first declared variable, to ensure that it is at the same location in the contracts to which calls are delegated.
     // To reduce deployment costs this variable is internal and needs to be retrieved via `getStorageAt`

--- a/contracts/proxies/IProxyCreationCallback.sol
+++ b/contracts/proxies/IProxyCreationCallback.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.3;
-import "./Proxy.sol";
+import "./GnosisSafeProxy.sol";
 
 interface IProxyCreationCallback {
-    function proxyCreated(Proxy proxy, address _mastercopy, bytes calldata initializer, uint256 saltNonce) external;
+    function proxyCreated(GnosisSafeProxy proxy, address _mastercopy, bytes calldata initializer, uint256 saltNonce) external;
 }

--- a/contracts/proxies/ProxyFactory.sol
+++ b/contracts/proxies/ProxyFactory.sol
@@ -1,21 +1,21 @@
 pragma solidity ^0.5.3;
-import "./Proxy.sol";
+import "./GnosisSafeProxy.sol";
 import "./IProxyCreationCallback.sol";
 
 /// @title Proxy Factory - Allows to create new proxy contact and execute a message call to the new proxy within one transaction.
 /// @author Stefan George - <stefan@gnosis.pm>
 contract ProxyFactory {
 
-    event ProxyCreation(Proxy proxy);
+    event ProxyCreation(GnosisSafeProxy proxy);
 
     /// @dev Allows to create new proxy contact and execute a message call to the new proxy within one transaction.
     /// @param masterCopy Address of master copy.
     /// @param data Payload for message call sent to new proxy contract.
     function createProxy(address masterCopy, bytes memory data)
         public
-        returns (Proxy proxy)
+        returns (GnosisSafeProxy proxy)
     {
-        proxy = new Proxy(masterCopy);
+        proxy = new GnosisSafeProxy(masterCopy);
         if (data.length > 0)
             // solium-disable-next-line security/no-inline-assembly
             assembly {

--- a/test/gnosisSafeTransactionExecution.js
+++ b/test/gnosisSafeTransactionExecution.js
@@ -158,7 +158,7 @@ contract('GnosisSafe with refunds', function(accounts) {
 
         let gasPrice = (new BigNumber('2')).pow(256).div(80000).toNumber()
 
-        // Should revert as we have an overflow (no message, as SafeMath doesn't support messages yet)
+        // Should revert as we have an overflow (no message, as GnosisSafeMath doesn't support messages yet)
         await safeUtils.executeTransaction(lw, gnosisSafe, 'executeTransaction withdraw 0.5 ETH', [lw.accounts[0], lw.accounts[2]], accounts[0], web3.toWei(0.5, 'ether'), "0x", CALL, executor, { revertMessage: "", gasPrice: gasPrice})
 
         let executorDiff = await web3.eth.getBalance(executor) - executorBalance


### PR DESCRIPTION
The safe contract project is currently using its own (local) implementations of two standard contracts: `Proxy.sol` and `SafeMath.sol`.  When trying to integrate with another truffle project that also uses these from more appropriate/recent sources (`@gnosis.pm/util-contracts` and `open-zeppelin` respectively) there are collisions on at compile time (because truffle can't handle it).

These changes address and close #176 in a way that shouldn't require another audit.