### PR TITLE
Update ConfirmedTransactionsModule

### DIFF
--- a/contracts/modules/ConfirmedTransactionModule.sol
+++ b/contracts/modules/ConfirmedTransactionModule.sol
@@ -1,0 +1,69 @@
+
+pragma solidity >=0.5.0 <0.7.0;
+import "../base/Module.sol";
+import "../base/ModuleManager.sol";
+import "../base/OwnerManager.sol";
+import "../common/Enum.sol";
+// Enables the Safe to designate transactions that can be
+// executed by an executor at any time. The set of executors
+// is also managed by the Safe.
+contract ConfirmedTransactionModule is Module {
+    string public constant NAME = "Confirmed Transaction Module";
+    string public constant VERSION = "0.1.0";   
+    mapping (bytes32 => bool) public confirmed;
+    mapping (bytes32 => bool) public executed;
+    mapping (address => bool) public executors;
+    function setup()
+        public
+    {
+        setManager();
+    }
+    function setExecutor(address executor, bool allowed) 
+        public
+        authorized
+    {
+        executors[executor] = allowed;
+    }
+    function confirmTransaction(bytes32 transactionHash)
+        public
+        authorized
+    {
+        require(!confirmed[transactionHash], "already confirmed");
+        confirmed[transactionHash] = true;
+    }
+    function revokeTransaction(bytes32 transactionHash)
+        public
+        authorized
+    {
+        require(confirmed[transactionHash], "not confirmed");    
+        require(!executed[transactionHash], "already executed");
+        confirmed[transactionHash] = false;
+    }    
+    function executeTransaction(
+        address to,
+        uint256 amount,
+        bytes memory data,
+        Enum.Operation operation
+    )
+        public
+    {
+        require(executors[msg.sender], "Can only be called by an executor");
+        bytes32 h = transactionHash(to, amount, data, operation);
+        require(confirmed[h], "tx is not marked as confirmed");
+        require(!executed[h], "tx has already been executed");
+        executed[h] = true;
+        require(manager.execTransactionFromModule(to, amount, data, operation), "tx failed");
+    }
+    function transactionHash(
+        address to,
+        uint256 amount,
+        bytes memory data,
+        Enum.Operation operation    
+    )
+        public pure
+        returns (bytes32)
+    {
+        require(operation == Enum.Operation.Call || operation == Enum.Operation.DelegateCall, "unknown operation");
+        return keccak256(abi.encode(to, amount, data, operation));
+    }
+}

--- a/migrations/6_deploy_confirm_module.js
+++ b/migrations/6_deploy_confirm_module.js
@@ -1,0 +1,8 @@
+var ConfirmedTransactionModule = artifacts.require("./ConfirmedTransactionModule.sol");
+
+module.exports = function(deployer) {
+    deployer.deploy(ConfirmedTransactionModule).then(function (module) {
+        module.setup()
+        return module
+    });
+};

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "deploy": "run(){ truffle deploy --network=$@; }; run",
     "do": "run(){ truffle exec --network=$@; }; run",
     "prepare": "yarn truffle compile && yarn tnt iN",
-    "preversion": "node scripts/clean_build.js && yarn tnt cB"
+    "preversion": "node scripts/clean_build.js && yarn tnt cB",
+    "merge": "sol-merger \"./contracts/modules/ConfirmedTransactionModule.sol\" ./merged"
   },
   "repository": {
     "type": "git",
@@ -64,6 +65,7 @@
     "ipfs-http-client": "^44.2.0",
     "random-buffer": "*",
     "run-with-testrpc": "^0.3.0",
+    "sol-merger": "^3.1.0",
     "solidity-coverage": "^0.7.4",
     "web3": "^1.2.6"
   },


### PR DESCRIPTION
I think the ConfirmedTransactionsModule needs the following modifications. I'm still learning the Safe Module system, so I'd like to hear your thoughts on it:
- The confirmTransaction() and revokeTransaction() functions have the authorized modifier, which means it's only executable by a single manager address. For most modules, this manager address is the Safe address, and proposals will have to be created to call the function. However, for our use case, we want to skip this entirely and cannot set it to the Safe address. (That would mean confirming a transaction is itself a Safe proposal.) In fact, since the module is meant to replace the new confirmation flow, I think we no longer need to use the manager address in the module.
- Instead, we need to change this authorized modifier to a custom onlyOwner  modifier similar to https://github.com/gnosis/safe-contracts/blob/development/contracts/modules/SocialRecoveryModule.sol#L54

Is my thinking correct on this?

Another question I have is: why do we need to maintain a separate executors list?