### PR TITLE
Sort checksummed addresses correctly

### DIFF
--- a/test/gnosisSafeEthSign.js
+++ b/test/gnosisSafeEthSign.js
@@ -56,7 +56,7 @@ contract('GnosisSafe using eth_sign', function(accounts) {
         let signer = async function(to, value, data, operation, txGasEstimate, baseGasEstimate, gasPrice, txGasToken, refundReceiver, nonce) {
             let txHash = await gnosisSafe.getTransactionHash(to, value, data, operation, txGasEstimate, baseGasEstimate, gasPrice, txGasToken, refundReceiver, nonce)
             let signatureBytes = "0x"
-            confirmingAccounts.sort()
+            confirmingAccounts.sort(utils.compareAddresses)
             for (var i=0; i<confirmingAccounts.length; i++) {
                 // Adjust v (it is + 27 => EIP-155 and + 4 to differentiate them from typed data signatures in the Safe)
                 let signature = (await ethSign(confirmingAccounts[i], txHash)).replace('0x', '').replace(/00$/,"1f").replace(/01$/,"20")

--- a/test/gnosisSafeEthSignTypeData.js
+++ b/test/gnosisSafeEthSignTypeData.js
@@ -91,7 +91,7 @@ contract('GnosisSafe using eth_signTypedData', function(accounts) {
                 }
             }
             let signatureBytes = "0x"
-            confirmingAccounts.sort()
+            confirmingAccounts.sort(utils.compareAddresses)
             for (var i=0; i<confirmingAccounts.length; i++) {
                 signatureBytes += (await signTypedData(confirmingAccounts[i], typedData)).replace('0x', '')
             }

--- a/test/gnosisSafeNestedSafes.js
+++ b/test/gnosisSafeNestedSafes.js
@@ -81,7 +81,7 @@ contract('GnosisSafe using nested safes', function(accounts) {
         let encodedOwner2Signs = abi.rawEncode(['bytes'], [ new Buffer(owner2Sigs, 'hex') ]).toString('hex').slice(64)
 
         // Pack signatures in correct order
-        if (owner1Safe.address < owner2Safe.address) {
+        if (utils.compareAddresses(owner1Safe.address, owner2Safe.address) < 0) {
             sigs += "000000000000000000000000" + owner1Safe.address.replace('0x', '') + "0000000000000000000000000000000000000000000000000000000000000082" + "00" // r, s, v
             sigs += "000000000000000000000000" + owner2Safe.address.replace('0x', '') + "00000000000000000000000000000000000000000000000000000000000000a2" + "00" // r, s, v
         } else {

--- a/test/gnosisSafeSignatureTypes.js
+++ b/test/gnosisSafeSignatureTypes.js
@@ -24,7 +24,7 @@ contract('GnosisSafe without refund', function(accounts) {
         assert.equal(await utils.getErrorMessage(gnosisSafe.address, 0, approveData, executor), "Only owners can approve a hash")
 
         let sigs = "0x"
-        for (let account of (accounts.sort())) {
+        for (let account of (accounts.sort(utils.compareAddresses))) {
             if (account != txSender) {
                 utils.logGasUsage("confirm by hash " + subject + " with " + account, await gnosisSafe.approveHash(txHash, {from: account}))
             }

--- a/test/utils/general.js
+++ b/test/utils/general.js
@@ -11,6 +11,16 @@ const formatAddress = (address) => web3.utils.toChecksumAddress(address)
 
 const formatAddresses = (addressArray) => addressArray.map((o) => web3.utils.toChecksumAddress(o))
 
+function compareAddresses(address1, address2) {
+    const normalizedAddress1 = web3.utils.padLeft(address1.toLowerCase(), 20);
+    const normalizedAddress2 = web3.utils.padLeft(address2.toLowerCase(), 20);
+
+    if (normalizedAddress1 == normalizedAddress2)
+        return 0;
+    else
+        return (normalizedAddress1 < normalizedAddress2 ? -1 : 1);
+}
+
 function createAndAddModulesData(dataArray) {
     // Remove method id (10) and position of data in payload (64)
     return dataArray.reduce((acc, data) => acc + ModuleDataWrapper.methods.setup(data).encodeABI().substr(74), "0x")
@@ -111,7 +121,7 @@ async function createLightwallet() {
 
 function signTransaction(lw, signers, transactionHash) {
     let signatureBytes = "0x"
-    signers.sort()
+    signers.sort(compareAddresses)
     for (var i=0; i<signers.length; i++) {
         let sig = lightwallet.signing.signMsgHash(lw.keystore, lw.passwords, transactionHash, signers[i])
         signatureBytes += sig.r.toString('hex') + sig.s.toString('hex') + sig.v.toString(16)
@@ -174,6 +184,7 @@ Object.assign(exports, {
     Address0,
     formatAddress,
     formatAddresses,
+    compareAddresses,
     web3ContactFactory,
     createAndAddModulesData,
     currentTimeNs,


### PR DESCRIPTION
This PR fixes random failures of the test suite caused by [`GnosisSafe` receiving incorrectly sorted addresses and rejecting them](https://github.com/gnosis/safe-contracts/blob/v1.2.0/contracts/GnosisSafe.sol#L257-L260). I saw it happen once in your CI (see [Travis build #582](https://travis-ci.org/github/gnosis/safe-contracts/builds/677327149)) and now that we're trying to run these tests on every PR in Solidity repo (and each check reruns them 3 times with different optimization levels), this happens all the time.

The issue is that `web3.js` at some point started returning checksummed addresses from `web3.eth.getAccounts()` and that's what Truffle uses to provide fresh addresses in tests (see https://github.com/trufflesuite/truffle/issues/1610). Since checksummed addresses are mixed-case, the lexicographical sort used in tests does not always result in increasing numerical values. This happens only if you happen to draw a set of addresses starting with both lower- and upper-case letters.

### Failing test output
```
  Contract: GnosisSafe without refund

(...)

    Gas costs for confirm by hash remove owner and reduce threshold to 2 with 0xB7670A456046645c1678b55C16C0556Ac5B13558: 46878
    Gas costs for confirm by hash remove owner and reduce threshold to 2 with 0xFF04404fE7469cA9EA59D06c186f02E87e8d5C97: 46878
    Gas costs for confirm by hash remove owner and reduce threshold to 2 with 0xb133f3CB81cA5cE77abAE733A2d45879c1B15c1E: 46878
    1) should add, remove and replace an owner and update the threshold

(...)

 1) Contract: GnosisSafe without refund
       should add, remove and replace an owner and update the threshold:

(...)

  Error: Transaction: 0xaa53811148aa8f6848728847eadf5d6f1e3ce5148ac216cc7abac76fb4c43311 exited with an error (status 0). Reason given: Invalid owner provided.    at PromiEvent (node_modules/truffle/build/webpack:/packages/contract/lib/promievent.js:9:1)
      at TruffleContract.execTransaction (node_modules/truffle/build/webpack:/packages/contract/lib/execute.js:169:1)
      at executeTransaction (test/gnosisSafeSignatureTypes.js:34:35)
      at process._tickCallback (internal/process/next_tick.js:68:7)
```

As you can see, the addresses in the order string sort produces are:
- `0xB7670A456046645c1678b55C16C0556Ac5B13558`
- `0xFF04404fE7469cA9EA59D06c186f02E87e8d5C97`
- `0xb133f3CB81cA5cE77abAE733A2d45879c1B15c1E`

When sorted correctly, as numbers, `0xb133f3CB81cA5cE77abAE733A2d45879c1B15c1E` should be first instead.