### PR TITLE
Closes #244: Prevent duplicate owners on setup

### DIFF
--- a/contracts/base/OwnerManager.sol
+++ b/contracts/base/OwnerManager.sol
@@ -34,7 +34,7 @@ contract OwnerManager is SelfAuthorized {
         for (uint256 i = 0; i < _owners.length; i++) {
             // Owner address cannot be null.
             address owner = _owners[i];
-            require(owner != address(0) && owner != SENTINEL_OWNERS, "Invalid owner address provided");
+            require(owner != address(0) && owner != SENTINEL_OWNERS && owner != address(this), "Invalid owner address provided");
             // No duplicate owners allowed.
             require(owners[owner] == address(0), "Duplicate owner address provided");
             owners[currentOwner] = owner;
@@ -54,8 +54,8 @@ contract OwnerManager is SelfAuthorized {
         public
         authorized
     {
-        // Owner address cannot be null.
-        require(owner != address(0) && owner != SENTINEL_OWNERS, "Invalid owner address provided");
+        // Owner address cannot be null, the sentinel or the Safe itself.
+        require(owner != address(0) && owner != SENTINEL_OWNERS && owner != address(this), "Invalid owner address provided");
         // No duplicate owners allowed.
         require(owners[owner] == address(0), "Address is already an owner");
         owners[owner] = owners[SENTINEL_OWNERS];
@@ -101,8 +101,8 @@ contract OwnerManager is SelfAuthorized {
         public
         authorized
     {
-        // Owner address cannot be null.
-        require(newOwner != address(0) && newOwner != SENTINEL_OWNERS, "Invalid owner address provided");
+        // Owner address cannot be null, the sentinel or the Safe itself.
+        require(newOwner != address(0) && newOwner != SENTINEL_OWNERS && newOwner != address(this), "Invalid owner address provided");
         // No duplicate owners allowed.
         require(owners[newOwner] == address(0), "Address is already an owner");
         // Validate oldOwner address and check that it corresponds to owner index.

--- a/contracts/base/OwnerManager.sol
+++ b/contracts/base/OwnerManager.sol
@@ -34,7 +34,7 @@ contract OwnerManager is SelfAuthorized {
         for (uint256 i = 0; i < _owners.length; i++) {
             // Owner address cannot be null.
             address owner = _owners[i];
-            require(owner != address(0) && owner != SENTINEL_OWNERS && owner != address(this), "Invalid owner address provided");
+            require(owner != address(0) && owner != SENTINEL_OWNERS && owner != address(this) && currentOwner != owner, "Invalid owner address provided");
             // No duplicate owners allowed.
             require(owners[owner] == address(0), "Duplicate owner address provided");
             owners[currentOwner] = owner;

--- a/test/core/GnosisSafe.OwnerManager.spec.ts
+++ b/test/core/GnosisSafe.OwnerManager.spec.ts
@@ -24,6 +24,14 @@ describe("OwnerManager", async () => {
             await expect(safe.addOwnerWithThreshold(user2.address, 1)).to.be.revertedWith("Method can only be called from this contract")
         })
 
+        it('can not set Safe itself', async () => {
+            const { safe } = await setupTests()
+
+            await expect(
+                executeContractCallWithSigners(safe, safe, "addOwnerWithThreshold", [safe.address, 1], [user1])
+            ).to.emit(safe, "ExecutionFailure")
+        })
+
         it('can not set sentinel', async () => {
             const { safe } = await setupTests()
 
@@ -200,6 +208,14 @@ describe("OwnerManager", async () => {
         it('can only be called from Safe itself', async () => {
             const { safe } = await setupTests()
             await expect(safe.swapOwner(AddressOne, user1.address, user2.address)).to.be.revertedWith("Method can only be called from this contract")
+        })
+
+        it('can not swap in Safe itseld', async () => {
+            const { safe } = await setupTests()
+
+            await expect(
+                executeContractCallWithSigners(safe, safe, "swapOwner", [AddressOne, user1.address, safe.address], [user1])
+            ).to.emit(safe, "ExecutionFailure")
         })
 
         it('can not swap in sentinel', async () => {

--- a/test/core/GnosisSafe.Setup.spec.ts
+++ b/test/core/GnosisSafe.Setup.spec.ts
@@ -87,11 +87,11 @@ describe("GnosisSafe", async () => {
             ).to.be.revertedWith("Invalid owner address provided")
         })
 
-        it.skip('should revert if same owner is included twice one after each other', async () => {
+        it('should revert if same owner is included twice one after each other', async () => {
             const { template } = await setupTests()
             await expect(
-                template.setup([user1.address, user2.address, user2.address], 2, AddressZero, "0x", AddressZero, AddressZero, 0, AddressZero)
-            ).to.be.revertedWith("Domain Separator already set!")
+                template.setup([user2.address, user2.address], 2, AddressZero, "0x", AddressZero, AddressZero, 0, AddressZero)
+            ).to.be.revertedWith("Invalid owner address provided")
         })
 
         it('should revert if threshold is too high', async () => {

--- a/test/core/GnosisSafe.Setup.spec.ts
+++ b/test/core/GnosisSafe.Setup.spec.ts
@@ -73,6 +73,13 @@ describe("GnosisSafe", async () => {
             ).to.be.revertedWith("Invalid owner address provided")
         })
 
+        it('should revert if Safe itself is used as an owner', async () => {
+            const { template } = await setupTests()
+            await expect(
+                template.setup([user2.address, template.address], 2, AddressZero, "0x", AddressZero, AddressZero, 0, AddressZero)
+            ).to.be.revertedWith("Invalid owner address provided")
+        })
+
         it('should revert if sentinel is used as an owner', async () => {
             const { template } = await setupTests()
             await expect(


### PR DESCRIPTION
Closes #244 

- Adds check to setup that includes the duplication check on the `currentOwner` that has not yet been persisted
