### PR TITLE
Closes #209: Add event for incoming eth

### DIFF
--- a/contracts/common/EtherPaymentFallback.sol
+++ b/contracts/common/EtherPaymentFallback.sol
@@ -6,13 +6,13 @@ pragma solidity >=0.7.0 <0.9.0;
 /// @author Richard Meissner - <richard@gnosis.pm>
 contract EtherPaymentFallback {
 
-    event Received(address indexed sender, uint256 value);
+    event SafeReceived(address indexed sender, uint256 value);
 
     /// @dev Fallback function accepts Ether transactions.
     receive()
         external
         payable
     {
-        emit Received(msg.sender, msg.value);
+        emit SafeReceived(msg.sender, msg.value);
     }
 }

--- a/contracts/common/EtherPaymentFallback.sol
+++ b/contracts/common/EtherPaymentFallback.sol
@@ -6,11 +6,13 @@ pragma solidity >=0.7.0 <0.9.0;
 /// @author Richard Meissner - <richard@gnosis.pm>
 contract EtherPaymentFallback {
 
+    event Received(address indexed sender, uint256 value);
+
     /// @dev Fallback function accepts Ether transactions.
     receive()
         external
         payable
     {
-
+        emit Received(msg.sender, msg.value);
     }
 }

--- a/test/core/GnosisSafe.Execution.spec.ts
+++ b/test/core/GnosisSafe.Execution.spec.ts
@@ -108,7 +108,7 @@ describe("GnosisSafe", async () => {
         it('should emit payment in success event', async () => {
             const { safe } = await setupTests()
             const tx = buildSafeTransaction({
-                to: safe.address, nonce: await safe.nonce(), operation: 0, gasPrice: 1, safeTxGas: 100000, refundReceiver: user2.address
+                to: user1.address, nonce: await safe.nonce(), operation: 0, gasPrice: 1, safeTxGas: 100000, refundReceiver: user2.address
             })
 
             await user1.sendTransaction({ to: safe.address, value: parseEther("1") })
@@ -120,6 +120,7 @@ describe("GnosisSafe", async () => {
                 executeTx(safe, tx, [await safeApproveHash(user1, safe, tx, true)]).then((tx) => { executedTx = tx; return tx })
             ).to.emit(safe, "ExecutionSuccess")
             const receipt = await hre.ethers.provider.getTransactionReceipt(executedTx!!.hash)
+            console.log(receipt.logs)
             const successEvent = safe.interface.decodeEventLog("ExecutionSuccess", receipt.logs[0].data, receipt.logs[0].topics)
             expect(successEvent.txHash).to.be.eq(calculateSafeTransactionHash(safe, tx, await chainId()))
             // Gas costs are around 3000, so even if we specified a safeTxGas from 100000 we should not use more

--- a/test/core/GnosisSafe.Incoming.spec.ts
+++ b/test/core/GnosisSafe.Incoming.spec.ts
@@ -53,7 +53,7 @@ describe("GnosisSafe", async () => {
                 caller.callEth(safe.address, {
                     value: parseEther("1")
                 })
-            ).to.emit(safe, "Received").withArgs(caller.address, parseEther("1"))
+            ).to.emit(safe, "SafeReceived").withArgs(caller.address, parseEther("1"))
             await expect(await hre.ethers.provider.getBalance(safe.address)).to.be.deep.eq(parseEther("1"))
         })
 
@@ -65,7 +65,7 @@ describe("GnosisSafe", async () => {
                     to: safe.address,
                     value: parseEther("1")
                 })
-            ).to.emit(safe, "Received").withArgs(user1.address, parseEther("1"))
+            ).to.emit(safe, "SafeReceived").withArgs(user1.address, parseEther("1"))
             await expect(await hre.ethers.provider.getBalance(safe.address)).to.be.deep.eq(parseEther("1"))
         })
 

--- a/test/core/GnosisSafe.Incoming.spec.ts
+++ b/test/core/GnosisSafe.Incoming.spec.ts
@@ -18,6 +18,10 @@ describe("GnosisSafe", async () => {
             function sendEth(address payable safe) public payable returns (bool success) {
                 require(safe.send(msg.value));
             }
+            function callEth(address payable safe) public payable returns (bool success) {
+                (bool success,) = safe.call{ value: msg.value }("");
+                require(success);
+            }
         }`
         return {
             safe: await getSafeWithOwners([user1.address]),
@@ -30,23 +34,45 @@ describe("GnosisSafe", async () => {
         it('should be able to receive ETH via transfer', async () => {
             const { safe, caller } = await setupTests()
             // Notes: It is not possible to load storage + a call + emit event with 2300 gas
-            // Test Validator
-            await caller.transferEth(safe.address, { value: parseEther("1") })
-            await expect(await hre.ethers.provider.getBalance(safe.address)).to.be.deep.eq(parseEther("1"))
+            await expect(
+                caller.transferEth(safe.address, { value: parseEther("1") })
+            ).to.be.reverted
         })
 
         it('should be able to receive ETH via send', async () => {
             const { safe, caller } = await setupTests()
             // Notes: It is not possible to load storage + a call + emit event with 2300 gas
-            // Test Validator
-            await caller.sendEth(safe.address, { value: parseEther("1") })
+            await expect(
+                caller.sendEth(safe.address, { value: parseEther("1") })
+            ).to.be.reverted
+        })
+
+        it('should be able to receive ETH via call', async () => {
+            const { safe, caller } = await setupTests()
+            await expect(
+                caller.callEth(safe.address, {
+                    value: parseEther("1")
+                })
+            ).to.emit(safe, "Received").withArgs(caller.address, parseEther("1"))
+            await expect(await hre.ethers.provider.getBalance(safe.address)).to.be.deep.eq(parseEther("1"))
+        })
+
+
+        it('should be able to receive ETH via transaction', async () => {
+            const { safe } = await setupTests()
+            await expect(
+                user1.sendTransaction({
+                    to: safe.address,
+                    value: parseEther("1")
+                })
+            ).to.emit(safe, "Received").withArgs(user1.address, parseEther("1"))
             await expect(await hre.ethers.provider.getBalance(safe.address)).to.be.deep.eq(parseEther("1"))
         })
 
         it('should throw for incoming eth with data', async () => {
             const { safe } = await setupTests()
             await expect(
-                user1.sendTransaction({to: safe.address, value: 23, data: "0xbaddad"})
+                user1.sendTransaction({ to: safe.address, value: 23, data: "0xbaddad" })
             ).to.be.revertedWith("fallback function is not payable and was called with value 23")
         })
     })


### PR DESCRIPTION
Closes #209

- Added `SafeReceived` event
- Change `send` and `transfer` test to expect revert

Note: This PR is based on #277 