### PR TITLE
Closes #246: Add warning for _msgSender

### DIFF
--- a/contracts/GnosisSafe.sol
+++ b/contracts/GnosisSafe.sol
@@ -21,7 +21,7 @@ contract GnosisSafe
 
     using GnosisSafeMath for uint256;
 
-    string public constant VERSION = "1.2.0";
+    string public constant VERSION = "1.3.0";
 
     // keccak256(
     //     "EIP712Domain(uint256 chainId,address verifyingContract)"

--- a/contracts/handler/HandlerContext.sol
+++ b/contracts/handler/HandlerContext.sol
@@ -7,6 +7,8 @@ pragma solidity >=0.7.0 <0.9.0;
 contract HandlerContext {
 
     // This function does not rely on a trusted forwarder. Use the returned value only to check information against the calling manager.
+    /// @notice This is only reliable in combination with a FallbackManager that supports this (e.g. Safe contract >=1.3.0). 
+    ///         When using this functionality make sure that the linked _manager (aka msg.sender) supports this.
     function _msgSender() internal pure returns (address sender) {
         // The assembly code is more direct than the Solidity version using `abi.decode`.
         assembly { sender := shr(96, calldataload(sub(calldatasize(), 20))) }


### PR DESCRIPTION
Closes #246 
- Add warning for `_msgSender` to make it clear that only is supported with the correct manager
- Adjusted version string in contract to `1.3.0`