### PR TITLE
Update StorageAccessible implementation

### DIFF
--- a/test/core/GnosisSafe.StorageAccessible.spec.ts
+++ b/test/core/GnosisSafe.StorageAccessible.spec.ts
@@ -40,26 +40,26 @@ describe("StorageAccessible", async () => {
         })
     })
 
-    describe("simulate", async () => {
+    describe("simulateDelegatecallInternal", async () => {
 
         it('should revert changes', async () => {
             const { safe, killLib } = await setupTests()
             await expect(
-                safe.callStatic.simulate(killLib.address, killLib.interface.encodeFunctionData("killme"))
+                safe.callStatic.simulateDelegatecallInternal(killLib.address, killLib.interface.encodeFunctionData("killme"))
             ).to.be.reverted
         })
 
         it('should revert the revert with message', async () => {
             const { safe, killLib } = await setupTests()
             await expect(
-                safe.callStatic.simulate(killLib.address, killLib.interface.encodeFunctionData("trever"))
-            ).to.revertedWith("Why are you doing this?")
+                safe.callStatic.simulateDelegatecallInternal(killLib.address, killLib.interface.encodeFunctionData("trever"))
+            ).to.be.reverted
         })
 
         it('should return estimate in revert', async () => {
             const { safe, killLib } = await setupTests()
             await expect(
-                safe.callStatic.simulate(killLib.address, killLib.interface.encodeFunctionData("estimate", [safe.address, "0x"]))
+                safe.callStatic.simulateDelegatecallInternal(killLib.address, killLib.interface.encodeFunctionData("estimate", [safe.address, "0x"]))
             ).to.be.reverted
         })
     })


### PR DESCRIPTION
Veondor code from latest version of StorageAcccessible (see https://github.com/gnosis/util-contracts/blob/solc-7/contracts/StorageAccessible.sol)

It is expected that the same is used by GPv2 therefore the interface is kept the same so it will be possible to share related tool/ code.