### PR TITLE
Optimize delegatecall check

### DIFF
--- a/contracts/accessors/SimulateTxAccessor.sol
+++ b/contracts/accessors/SimulateTxAccessor.sol
@@ -6,15 +6,14 @@ import "../base/Executor.sol";
 /// @title Simulate Transaction Accessor - can be used with StorageAccessible to simulate Safe transactions
 /// @author Richard Meissner - <richard@gnosis.pm>
 contract SimulateTxAccessor is Executor {
-    bytes32 private constant GUARD_VALUE = keccak256("simulate_tx_accessor.guard.bytes32");
-    bytes32 private guard;
+    address private immutable accessorSingleton;
 
     constructor() {
-        guard = GUARD_VALUE;
+        accessorSingleton = address(this);
     }
 
     modifier onlyDelegateCall() {
-        require(guard != GUARD_VALUE, "SimulateTxAccessor should only be called via delegatecall");
+        require(address(this) != accessorSingleton, "SimulateTxAccessor should only be called via delegatecall");
         _;
     }
 

--- a/contracts/libraries/Migrate_1_3_0_to_1_2_0.sol
+++ b/contracts/libraries/Migrate_1_3_0_to_1_2_0.sol
@@ -4,15 +4,15 @@ pragma solidity >=0.7.0 <0.9.0;
 /// @title Migration - migrates a Safe contract from 1.3.0 to 1.2.0
 /// @author Richard Meissner - <richard@gnosis.io>
 contract Migration {
-    bytes32 private constant GUARD_VALUE = keccak256("migration_130_to_120.guard.bytes32");
     bytes32 private constant DOMAIN_SEPARATOR_TYPEHASH = 0x035aff83d86937d35b32e04f0ddc6ff469290eef2f1b692d8a815c89404d4749;
 
+    address public immutable migrationSingleton;
     address public immutable safe120Singleton;
 
     constructor(address targetSingleton) {
         require(targetSingleton != address(0), "Invalid singleton address provided");
         safe120Singleton = targetSingleton;
-        guard = GUARD_VALUE;
+        migrationSingleton = address(this);
     }
 
     event ChangedMasterCopy(address singleton);
@@ -33,7 +33,7 @@ contract Migration {
 
     /// @dev Allows to migrate the contract. This can only be called via a delegatecall.
     function migrate() public {
-        require(guard != GUARD_VALUE, "Migration should only be called via delegatecall");
+        require(address(this) != migrationSingleton, "Migration should only be called via delegatecall");
         // Master copy address cannot be null.
         singleton = safe120Singleton;
         domainSeparator = keccak256(abi.encode(DOMAIN_SEPARATOR_TYPEHASH, this));

--- a/contracts/libraries/MultiSend.sol
+++ b/contracts/libraries/MultiSend.sol
@@ -7,12 +7,10 @@ pragma solidity >=0.7.0 <0.9.0;
 /// @author Stefan George - <stefan@gnosis.io>
 /// @author Richard Meissner - <richard@gnosis.io>
 contract MultiSend {
-    bytes32 private constant GUARD_VALUE = keccak256("multisend.guard.bytes32");
-
-    bytes32 private guard;
+    address private immutable multisendSingleton;
 
     constructor() {
-        guard = GUARD_VALUE;
+        multisendSingleton = address(this);
     }
 
     /// @dev Sends multiple transactions and reverts all if one fails.
@@ -26,7 +24,7 @@ contract MultiSend {
     /// @notice This method is payable as delegatecalls keep the msg.value from the previous call
     ///         If the calling method (e.g. execTransaction) received ETH this would revert otherwise
     function multiSend(bytes memory transactions) public payable {
-        require(guard != GUARD_VALUE, "MultiSend should only be called via delegatecall");
+        require(address(this) != multisendSingleton, "MultiSend should only be called via delegatecall");
         // solhint-disable-next-line no-inline-assembly
         assembly {
             let length := mload(transactions)

--- a/test/migration/subTests.spec.ts
+++ b/test/migration/subTests.spec.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 import { Contract } from "@ethersproject/contracts"
 import { parseEther } from "@ethersproject/units"
 import { expect } from "chai";


### PR DESCRIPTION
Replace guards with immutable that can be used to check against `this` at runtime