### PR TITLE
Add checkNSignatures method

### DIFF
--- a/contracts/libraries/Migrate_1_3_0_to_1_2_0.sol
+++ b/contracts/libraries/Migrate_1_3_0_to_1_2_0.sol
@@ -25,7 +25,7 @@ contract Migration {
     bytes32 private _slot3;
     bytes32 private _slot4;
     bytes32 private _slot5;
-    // For the migration we need to set the old domain seperator in storage
+    // For the migration we need to set the old domain separator in storage
     bytes32 private domainSeparator;
 
     // Define guard last to avoid conflict with Safe storage layout

--- a/test/core/GnosisSafe.Signatures.spec.ts
+++ b/test/core/GnosisSafe.Signatures.spec.ts
@@ -230,7 +230,7 @@ describe("GnosisSafe", async () => {
             ).to.be.revertedWith("GS021")
         })
 
-        it('should fail if sigantures data is not present', async () => {
+        it('should fail if signatures data is not present', async () => {
             const { safe } = await setupTests()
             const tx = buildSafeTransaction({ to: safe.address, nonce: await safe.nonce() })
             const txHashData = preimageSafeTransactionHash(safe, tx, await chainId())
@@ -243,7 +243,7 @@ describe("GnosisSafe", async () => {
             ).to.be.revertedWith("GS022")
         })
 
-        it('should fail if sigantures data is too short', async () => {
+        it('should fail if signatures data is too short', async () => {
             const { safe } = await setupTests()
             const tx = buildSafeTransaction({ to: safe.address, nonce: await safe.nonce() })
             const txHashData = preimageSafeTransactionHash(safe, tx, await chainId())
@@ -333,6 +333,156 @@ describe("GnosisSafe", async () => {
             ])
 
             await safe.checkSignatures(txHash, txHashData, signatures)
+        })
+    })
+
+    describe("checkSignatures", async () => {
+        it('should fail if signature points into static part', async () => {
+            const { safe } = await setupTests()
+            const tx = buildSafeTransaction({ to: safe.address, nonce: await safe.nonce() })
+            const txHashData = preimageSafeTransactionHash(safe, tx, await chainId())
+            const txHash = calculateSafeTransactionHash(safe, tx, await chainId())
+            const signatures = "0x" + "000000000000000000000000" + user1.address.slice(2) + "0000000000000000000000000000000000000000000000000000000000000020" + "00" + // r, s, v  
+                "0000000000000000000000000000000000000000000000000000000000000000" // Some data to read
+            await expect(
+                safe.checkNSignatures(txHash, txHashData, signatures, 1)
+            ).to.be.revertedWith("GS021")
+        })
+
+        it('should fail if signatures data is not present', async () => {
+            const { safe } = await setupTests()
+            const tx = buildSafeTransaction({ to: safe.address, nonce: await safe.nonce() })
+            const txHashData = preimageSafeTransactionHash(safe, tx, await chainId())
+            const txHash = calculateSafeTransactionHash(safe, tx, await chainId())
+
+            const signatures = "0x" + "000000000000000000000000" + user1.address.slice(2) + "0000000000000000000000000000000000000000000000000000000000000041" + "00" // r, s, v
+
+            await expect(
+                safe.checkNSignatures(txHash, txHashData, signatures, 1)
+            ).to.be.revertedWith("GS022")
+        })
+
+        it('should fail if signatures data is too short', async () => {
+            const { safe } = await setupTests()
+            const tx = buildSafeTransaction({ to: safe.address, nonce: await safe.nonce() })
+            const txHashData = preimageSafeTransactionHash(safe, tx, await chainId())
+            const txHash = calculateSafeTransactionHash(safe, tx, await chainId())
+
+            const signatures = "0x" + "000000000000000000000000" + user1.address.slice(2) + "0000000000000000000000000000000000000000000000000000000000000041" + "00" + // r, s, v
+                "0000000000000000000000000000000000000000000000000000000000000020" // length
+
+            await expect(
+                safe.checkNSignatures(txHash, txHashData, signatures, 1)
+            ).to.be.revertedWith("GS023")
+        })
+
+        it('should not be able to use different chainId for signing', async () => {
+            await setupTests()
+            const safe = await getSafeWithOwners([user1.address])
+            const tx = buildSafeTransaction({ to: safe.address, nonce: await safe.nonce() })
+            const txHashData = preimageSafeTransactionHash(safe, tx, await chainId())
+            const txHash = calculateSafeTransactionHash(safe, tx, await chainId())
+            const signatures = buildSignatureBytes([await safeSignTypedData(user1, safe, tx, 1)])
+            await expect(
+                safe.checkNSignatures(txHash, txHashData, signatures, 1)
+            ).to.be.revertedWith("GS026")
+        })
+
+        it('if not msg.sender on-chain approval is required', async () => {
+            const { safe } = await setupTests()
+            const user2Safe = safe.connect(user2)
+            const tx = buildSafeTransaction({ to: safe.address, nonce: await safe.nonce() })
+            const txHashData = preimageSafeTransactionHash(safe, tx, await chainId())
+            const txHash = calculateSafeTransactionHash(safe, tx, await chainId())
+            const signatures = buildSignatureBytes([await safeApproveHash(user1, safe, tx, true)])
+            await expect(
+                user2Safe.checkNSignatures(txHash, txHashData, signatures, 1)
+            ).to.be.revertedWith("GS025")
+        })
+
+        it('should revert if not the required amount of signature data is provided', async () => {
+            await setupTests()
+            const safe = await getSafeWithOwners([user1.address, user2.address, user3.address])
+            const tx = buildSafeTransaction({ to: safe.address, nonce: await safe.nonce() })
+            const txHashData = preimageSafeTransactionHash(safe, tx, await chainId())
+            const txHash = calculateSafeTransactionHash(safe, tx, await chainId())
+            await expect(
+                safe.checkNSignatures(txHash, txHashData, "0x", 1)
+            ).to.be.revertedWith("GS020")
+        })
+
+        it('should not be able to use different signature type of same owner', async () => {
+            await setupTests()
+            const safe = await getSafeWithOwners([user1.address, user2.address, user3.address])
+            const tx = buildSafeTransaction({ to: safe.address, nonce: await safe.nonce() })
+            const txHashData = preimageSafeTransactionHash(safe, tx, await chainId())
+            const txHash = calculateSafeTransactionHash(safe, tx, await chainId())
+            const signatures = buildSignatureBytes([
+                await safeApproveHash(user1, safe, tx),
+                await safeSignTypedData(user1, safe, tx),
+                await safeSignTypedData(user3, safe, tx)
+            ])
+            await expect(
+                safe.checkNSignatures(txHash, txHashData, signatures, 3)
+            ).to.be.revertedWith("GS026")
+        })
+
+        it('should be able to mix all signature types', async () => {
+            await setupTests()
+            const safe = await getSafeWithOwners([user1.address, user2.address, user3.address, user4.address])
+            const tx = buildSafeTransaction({ to: safe.address, nonce: await safe.nonce() })
+            const txHashData = preimageSafeTransactionHash(safe, tx, await chainId())
+            const txHash = calculateSafeTransactionHash(safe, tx, await chainId())
+            const signatures = buildSignatureBytes([
+                await safeApproveHash(user1, safe, tx, true),
+                await safeApproveHash(user4, safe, tx),
+                await safeSignTypedData(user2, safe, tx),
+                await safeSignTypedData(user3, safe, tx)
+            ])
+
+            await safe.checkNSignatures(txHash, txHashData, signatures, 3)
+        })
+
+        it('should be able to require no signatures', async () => {
+            await setupTests()
+            const safe = await getSafeTemplate()
+            const tx = buildSafeTransaction({ to: safe.address, nonce: await safe.nonce() })
+            const txHashData = preimageSafeTransactionHash(safe, tx, await chainId())
+            const txHash = calculateSafeTransactionHash(safe, tx, await chainId())
+
+            await safe.checkNSignatures(txHash, txHashData, "0x", 0)
+        })
+
+        it('should be able to require less signatures than the threshold', async () => {
+            await setupTests()
+            const safe = await getSafeWithOwners([user1.address, user2.address, user3.address, user4.address])
+            const tx = buildSafeTransaction({ to: safe.address, nonce: await safe.nonce() })
+            const txHashData = preimageSafeTransactionHash(safe, tx, await chainId())
+            const txHash = calculateSafeTransactionHash(safe, tx, await chainId())
+            const signatures = buildSignatureBytes([
+                await safeSignTypedData(user3, safe, tx)
+            ])
+
+            await safe.checkNSignatures(txHash, txHashData, signatures, 1)
+        })
+
+        it('should be able to require more signatures than the threshold', async () => {
+            await setupTests()
+            const safe = await getSafeWithOwners([user1.address, user2.address, user3.address, user4.address], 2)
+            const tx = buildSafeTransaction({ to: safe.address, nonce: await safe.nonce() })
+            const txHashData = preimageSafeTransactionHash(safe, tx, await chainId())
+            const txHash = calculateSafeTransactionHash(safe, tx, await chainId())
+            const signatures = buildSignatureBytes([
+                await safeApproveHash(user1, safe, tx, true),
+                await safeApproveHash(user4, safe, tx),
+                await safeSignTypedData(user2, safe, tx)
+            ])
+            // Should fail as only 3 signaures are provided
+            await expect(
+                safe.checkNSignatures(txHash, txHashData, signatures, 4)
+            ).to.be.revertedWith("GS020")
+
+            await safe.checkNSignatures(txHash, txHashData, signatures, 3)
         })
     })
 })


### PR DESCRIPTION
Adds `checkNSignatures` that allows to specify the number of expected signatures. This will allow external contracts (e.g. modules, guard or fallback handlers) to easily check signatures against the safe owners without having to rely on the threshold.

Examples:
- A transaction guard could check against all owners for specific transactions
- A EIP-1271 fallback handler could require less signatures for specific signatures.