### PR TITLE
Add dev warning to readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,7 +209,7 @@ Note: The encoding of the data send to the `multiSend` method is exactly the sam
 #### Add base contract for Gnosis Safe storage layout
 File: [`contracts/examples/libraries/GnosisSafeStorage.sol`](https://github.com/gnosis/safe-contracts/blob/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9/contracts/examples/libraries/GnosisSafeStorage.sol)
 
-Note: **This contract is meant as an example to demonstrate how access the Gnosis Safe state within a library contract. This should not be used in production without further checks.**
+Note: **This contract is meant as an example to demonstrate how to access the Gnosis Safe state within a library contract. This should not be used in production without further checks.**
 
 Expected behaviour:
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Gnosis Safe Contracts
 [![Build Status](https://github.com/gnosis/safe-contracts/workflows/safe-contracts/badge.svg?branch=development)](https://github.com/gnosis/safe-contracts/actions)
 [![Coverage Status](https://coveralls.io/repos/github/gnosis/safe-contracts/badge.svg?branch=development)](https://coveralls.io/github/gnosis/safe-contracts)
 
+> :warning: **This branch contains changes that are under development** To use the latest audited version make sure to use the correct commit. The tagged versions that are used by the Gnosis Safe team can be found in the [releases](https://github.com/gnosis/safe-contracts/releases).
+
 Usage
 -----
 ### Install requirements with yarn:


### PR DESCRIPTION
This should warn the developers that they should use the tagged versions to get the audited code