### PR TITLE
Remove the redundant AND operation of SignatureDecoder

### DIFF
--- a/contracts/common/SignatureDecoder.sol
+++ b/contracts/common/SignatureDecoder.sol
@@ -27,10 +27,7 @@ contract SignatureDecoder {
             s := mload(add(signatures, add(signaturePos, 0x40)))
             // Here we are loading the last 32 bytes, including 31 bytes
             // of 's'. There is no 'mload8' to do this.
-            //
-            // 'byte' is not working due to the Solidity parser, so lets
-            // use the second best option, 'and'
-            v := and(mload(add(signatures, add(signaturePos, 0x41))), 0xff)
+            v := mload(add(signatures, add(signaturePos, 0x41)))
         }
     }
 }


### PR DESCRIPTION
At the beginning, the variable v has been defined as uint8, so there is no need to convert the format in the assembly.